### PR TITLE
Update resonite.mdx to point at the original repo

### DIFF
--- a/docs/software/integrations/resonite.mdx
+++ b/docs/software/integrations/resonite.mdx
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Resonite
 
-Project Babble has a *mod-based* integration for Resonite. Its [setup instructions and download](https://github.com/Meister1593/ProjectBabbleResonite/releases) can both be found on the mod's Github page.
+Project Babble has a *mod-based* integration for Resonite. Its [setup instructions and download](https://github.com/dfgHiatus/ProjectBabble-Resonite/releases) can both be found on the mod's Github page.
 
 :::info
 The following is a copy of the README of the mod's README. It may be out of date, please check for any updates.
@@ -12,8 +12,8 @@ The following is a copy of the README of the mod's README. It may be out of date
 
 ## Usage
 1. Install [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoader).
-2. Place [ProjectBabbleResonite.dll](https://github.com/Meister1593/ProjectBabbleResonite/releases) into your `rml_mods` folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\Resonite\rml_mods` on windows or `$HOME/.steam/steam/steamapps/common/Resonite/rml_mods` on linux for a default installation. You can create it if it's missing, or if you launch the game once with ResoniteModLoader installed it will create the folder for you.
-3. Place [OscCore.dll](https://github.com/Meister1593/ProjectBabbleResonite/releases) into your Resonite base folder, one above your 'rml_mods' folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\Resonite` on windows or `$HOME/.steam/steam/steamapps/common/Resonite` on linux for a default installation.
+2. Place [ProjectBabbleResonite.dll](https://github.com/dfgHiatus/ProjectBabble-Resonite/releases) into your `rml_mods` folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\Resonite\rml_mods` on windows or `$HOME/.steam/steam/steamapps/common/Resonite/rml_mods` on linux for a default installation. You can create it if it's missing, or if you launch the game once with ResoniteModLoader installed it will create the folder for you.
+3. Place [OscCore.dll](https://github.com/dfgHiatus/ProjectBabble-Resonite/releases) into your Resonite base folder, one above your 'rml_mods' folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\Resonite` on windows or `$HOME/.steam/steam/steamapps/common/Resonite` on linux for a default installation.
 4. Load and run Project Babble's face tracking before starting Resonite.
 5. Start the game!
 


### PR DESCRIPTION
Changed the repo links for the resonite mod, to point at the original repo (owned by dfgHiatus), for a more up to date version of the mod.