### PR TITLE
Fixed images in Fine-Tuning and Troubleshooting section

### DIFF
--- a/docs/babbleofficaltracker/babbleofficaltracker.mdx
+++ b/docs/babbleofficaltracker/babbleofficaltracker.mdx
@@ -130,18 +130,17 @@ If some expressions work better on one side than the other, or you need to adjus
 
 ### Understanding the Calibration Tab
 
-![Calibration Panel](/img/babbleofficaltracker/11.png)
+![Calibration Panel](/img/babbleofficaltracker/12.png)
 
 The calibration panel allows you to manually adjust tracking values:
 
 - **Left/Right**: Indicates which side of the face the shape corresponds to
 
-![Left Right Options](/img/babbleofficaltracker/12.png)
+![Left Right Options](/img/babbleofficaltracker/13.png)
 
 - **Shapes**: The specific facial movement (left and/or right) being tracked (Mouth Open, Cheek Puff, etc.)
 
-![Shape Names](/img/babbleofficaltracker/13.png)
-![Minimum Value](/img/babbleofficaltracker/14.png)
+![Shape Names](/img/babbleofficaltracker/14.png)
 
 - **Min**: The threshold at which the model starts detecting a shape
 


### PR DESCRIPTION
Understanding the Calibration menu had Calibration mode image (11.png) -> changed to the propper one (12.png) Left/Right had the Calibration menu image (12.png) ->  changed to the propper one (13.png) Shapes had both Shapes image and minimun values image (14.png and 15.png) -> changed to just shapes image (14.png)