### PR TITLE
Fixed Esp32-S3 Wroom link

### DIFF
--- a/docs/hardware/components/ESP32s.mdx
+++ b/docs/hardware/components/ESP32s.mdx
@@ -27,7 +27,7 @@ title: Tracker Boards
   - Requires a separate programmer board for flashing firmware.
   - Supports only wireless streaming.
   - May need soldering to attach external antennas.
-  - [Buy on AliExpress](https://www.aliexpress.com/item/3256806346200289.html)
+  - [Buy on AliExpress](https://www.aliexpress.com/item/3256804774322524.html)
 
   **Note:** The ESPCAM32 module often requires a special programmer board to flash the firmware. While our listing includes it, be sure to check if it's included when purchasing from other sources.
 


### PR DESCRIPTION
Fixed the link for the wroom esp 32 to the one that can actually use a camera