### PR TITLE
Add link to tracker assembly video, steam page

### DIFF
--- a/docs/babbleofficaltracker/babbleofficaltracker.mdx
+++ b/docs/babbleofficaltracker/babbleofficaltracker.mdx
@@ -16,6 +16,9 @@ If you'd like to use your tracker in _Wireless_ mode, follow this [guide](docs/b
 ## Getting Started
 ### Hardware Setup
 
+**Assemble your tracker**
+1) Follow this video for how to assemble your tracker: [Unboxing and Assembling your Babble Tracker](https://www.youtube.com/watch?v=iPRabTew0KU)
+
 **Plug your tracker into your PC**
 1) Connect using the USB port on your tracker
 1) Make sure the switch is in the "ON" position, as seen below
@@ -27,7 +30,8 @@ If you'd like to use your tracker in _Wireless_ mode, follow this [guide](docs/b
 
 ### Software Setup
 #### Windows
-    - Get the latest version from our [Github](https://github.com/Project-Babble/Baballonia/releases/latest). Download the installer and run it.
+    - [Install Baballonia from Steam](https://store.steampowered.com/app/4091970/Project_Babble_Baballonia/)
+    - Alternatively, Get the latest version from our [Github](https://github.com/Project-Babble/Baballonia/releases/latest). Download the installer and run it.
 #### macOS/Linux
     - Currently, we do not offer installers for these platforms. You will need to build these from source.
     - For assistance building Babble Avalonia on these platforms, please contact us in our discord server.

--- a/docs/babbleofficaltracker/babbleofficaltrackerwireless.mdx
+++ b/docs/babbleofficaltracker/babbleofficaltrackerwireless.mdx
@@ -9,6 +9,9 @@ import ImageGallery from '@site/src/components/ImageGallery/ImageGallery';
 
 ## Hardware Setup
 
+**Assemble your tracker**
+1) Follow this video for how to assemble your tracker: [Unboxing and Assembling your Babble Tracker](https://www.youtube.com/watch?v=iPRabTew0KU)
+
 **Plug your tracker into your PC**
 1) Connect using the USB port on your tracker
 1) Make sure the switch is in the "ON" position, as seen below
@@ -20,7 +23,8 @@ import ImageGallery from '@site/src/components/ImageGallery/ImageGallery';
 
 ## Software Setup
 ### Windows
-    - Get the latest version from our [Github](https://github.com/Project-Babble/Baballonia/releases/latest). Download the installer and run it.
+    - [Install Baballonia from Steam](https://store.steampowered.com/app/4091970/Project_Babble_Baballonia/)
+    - Alternatively, Get the latest version from our [Github](https://github.com/Project-Babble/Baballonia/releases/latest). Download the installer and run it.
 ### macOS/Linux
     - Currently, we do not offer installers for these platforms. You will need to build these from source.
     - For assistance building Babble Avalonia on these platforms, please contact us in our discord server.


### PR DESCRIPTION
Add a link to the assembly video, as it's an important step for tracker setup and helps folks be sure they're correctly putting it together.

Add a steam page link as the main way to install on Windows.