### PR TITLE
Clarify Baballonia firmware support

### DIFF
--- a/docs/hardware/Firmware/diyfirmware.mdx
+++ b/docs/hardware/Firmware/diyfirmware.mdx
@@ -4,9 +4,9 @@ sidebar_position: 1
 ---
 
 :::info
-If you purchased a Babble PCB (by itself, as part of the Base Kit, or the Supporter Kit) you do *NOT* need to follow the directions below *if you are using it in wired mode.*
+If you purchased a Babble PCB (by itself, as part of the Base Kit, or the Supporter Kit) you do *NOT* need to follow the directions below.
 
-The following instructions are for users who have *assembled their own hardware* or people who wish to use the *wireless mode* with their *Babble Kit*.
+This guide is only for users who have *sourced seperate hardware*, which isn't supported by Baballonia's built in firmware installer.
 :::
 
 :::warning 


### PR DESCRIPTION
IMO there should be some note in the base Firmware file, but that could disrupt official tracker users. As noted on the discord. And blanket limitations should probably be noted somewhere.

Given the new support for official trackers in the Baballonia app, there should be no need at all for non-diy users to access this page. 